### PR TITLE
Updates for recent changes in lsp-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,6 @@ Since the stock fsharp layer does not currently include LSP support, you will ne
 cp -r spacemacs/fsharp2 ~/.emacs.d/private
 ```
 
-You may also wish to suppress warnings from lsp-mode, because FSharpLanguageServer emits some notifications that lsp-mode does not support. Note that this configuration applies to all LSP languages, not just F#.
-
-```
-(add-to-list 'warning-suppress-types '(lsp-mode))
-```
-
 Finally, make sure that you have these layers enabled in your dotspacemacs-configuration-layers. You will need to remove the fsharp layer if you have it, since fsharp2 conflicts with it.
 
 - lsp 

--- a/spacemacs/fsharp2/funcs.el
+++ b/spacemacs/fsharp2/funcs.el
@@ -18,15 +18,23 @@
    (setq fsharp-ac-intellisense-enabled t))))
 
 (defun spacemacs//fsharp2-setup-backend ()
- "Conditionally setup fsharp backend"
+  "Conditionally setup fsharp backend"
  (pcase fsharp2-backend
   (`lsp
    (require 'lsp)
+   ;; Required to avoid issues with lsp-mode's built-in F# client; even though 
+   ;; we're using our mode instead, lsp-mode can't build the LSP client 
+   ;; without this value defined
+   (setq lsp-fsharp-server-path "")
    (lsp-register-client
     (make-lsp-client
      :new-connection (lsp-stdio-connection fsharp2-lsp-executable)
      :major-modes '(fsharp-mode)
-     :server-id 'fsharp-lsp))
+     :server-id 'fsharp-lsp
+     :notification-handlers (ht ("fsharp/startProgress" #'ignore)
+                                ("fsharp/incrementProgress" #'ignore)
+                                ("fsharp/endProgress" #'ignore))
+     :priority 1))
    (lsp))))
 
 (defun spacemacs//fsharp2-setup-bindings ()


### PR DESCRIPTION
- We have to set lsp-fsharp-server-path to avoid crashing lsp-mode,
  since otherwise lsp-fsharp (the built-in one) will construct an
  invalid command when lsp-mode is initializing

- Prioritize fsharp2 over lsp-fsharp

- Explicitly ignore signals that lsp-mode can't process. That makes
  the advice about using warning-suppress-types obsolete.