### PR TITLE
Support .NET Core 3 projects

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,10 +4,10 @@ client/bin/**
 sample/**
 scripts/**
 src/**
-!src/FSharpLanguageServer/bin/Release/netcoreapp2.0/osx.10.11-x64/publish/**
-!src/FSharpLanguageServer/bin/Release/netcoreapp2.0/win10-x64/publish/**
-!src/FSharpLanguageServer/bin/Release/netcoreapp2.0/linux-x64/publish/**
-!src/FSharpLanguageServer/bin/Release/netcoreapp2.0/assembly/README.md
+!src/FSharpLanguageServer/bin/Release/netcoreapp3.0/osx.10.11-x64/publish/**
+!src/FSharpLanguageServer/bin/Release/netcoreapp3.0/win10-x64/publish/**
+!src/FSharpLanguageServer/bin/Release/netcoreapp3.0/linux-x64/publish/**
+!src/FSharpLanguageServer/bin/Release/netcoreapp3.0/assembly/README.md
 tests/**
 build.vsix
 fsharp-language-server.sln

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Install [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovi
 Update your vim config to point LanguageClient-neovim to the FSharp Language Server for fsharp filetypes:
 ```
 let g:LanguageClient_serverCommands = {
-    \ 'fsharp': ['dotnet', '/Users/name/code/fsharp-language-server/src/FSharpLanguageServer/bin/Release/netcoreapp2.0/target/FSharpLanguageServer.dll']
+    \ 'fsharp': ['dotnet', '/Users/name/code/fsharp-language-server/src/FSharpLanguageServer/bin/Release/netcoreapp3.0/target/FSharpLanguageServer.dll']
     \ }
 ```
 Open an fsharp file, move the cursor, and call functions. Mappings are up to you:
@@ -96,7 +96,7 @@ dotnet publish -c Release -r osx.10.11-x64 src/FSharpLanguageServer
 dotnet publish -c Release -r win10-x64 src/FSharpLanguageServer
 ```
 
-Make sure that the FSharpLanguageServer (in `src/FSharpLanguageServer/bin/Release/netcoreapp2.0/PLATFORM/publish`) is in your PATH. Alternatively, you can set the path to the server executable manually within your .spacemacs user-config:
+Make sure that the FSharpLanguageServer (in `src/FSharpLanguageServer/bin/Release/netcoreapp3.0/PLATFORM/publish`) is in your PATH. Alternatively, you can set the path to the server executable manually within your .spacemacs user-config:
 
 ```
 (setq fsharp2-lsp-executable "/path/to/FSharpLanguageServer")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 
 image:
-- Visual Studio 2017
+- Visual Studio 2019
 - Ubuntu
 before_build:
   # Display .NET Core version

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -216,7 +216,7 @@ function createProgressListeners(client: LanguageClient) {
 }
 
 function binName(): string {
-	var baseParts = ['src', 'FSharpLanguageServer', 'bin', 'Release', 'netcoreapp2.0'];
+	var baseParts = ['src', 'FSharpLanguageServer', 'bin', 'Release', 'netcoreapp3.0'];
 	var pathParts = getPathParts(process.platform);
 	var fullParts = baseParts.concat(pathParts);
 

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "extensionDependencies": [
-        "ms-vscode.csharp"
+        "ms-dotnettools.csharp"
     ],
     "dependencies": {
         "vscode-languageclient": "^4.2.1"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     ],
     "main": "./out/client/extension",
     "files": [
-        "./src/FSharpLanguageServer/bin/Release/netcoreapp2.0/osx.10.11-x64/publish",
-        "./src/FSharpLanguageServer/bin/Release/netcoreapp2.0/linux-x64/publish",
-        "./src/FSharpLanguageServer/bin/Release/netcoreapp2.0/win10-x64/publish"
+        "./src/FSharpLanguageServer/bin/Release/netcoreapp3.0/osx.10.11-x64/publish",
+        "./src/FSharpLanguageServer/bin/Release/netcoreapp3.0/linux-x64/publish",
+        "./src/FSharpLanguageServer/bin/Release/netcoreapp3.0/win10-x64/publish"
     ],
     "contributes": {
         "languages": [

--- a/sample/NetCoreApp3/NetCoreApp3.fsproj
+++ b/sample/NetCoreApp3/NetCoreApp3.fsproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="main.fs" />
+  </ItemGroup>
+
+</Project>

--- a/sample/NetCoreApp3/main.fs
+++ b/sample/NetCoreApp3/main.fs
@@ -1,0 +1,5 @@
+open System
+
+[<EntryPoint>]
+let main _ =
+    0

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 set -e
 

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Builds src/FSharpLanguageServer/bin/Release/netcoreapp2.0/osx.10.11-x64/publish/FSharpLanguageServer
+# Builds src/FSharpLanguageServer/bin/Release/netcoreapp3.0/osx.10.11-x64/publish/FSharpLanguageServer
 dotnet publish -c Release -r osx.10.11-x64 src/FSharpLanguageServer
 echo 'Press F5 to debug the new build of F# language server'

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -14,6 +14,7 @@ dotnet restore sample/ReferenceCSharp/ReferenceCSharp.fsproj
 dotnet restore sample/Signature/Signature.fsproj
 dotnet restore sample/SlnReferences/ReferencedProject.fsproj
 dotnet restore sample/TemplateParams/TemplateParams.fsproj
+dotnet restore sample/NetCoreApp3/NetCoreApp3.fsproj
 # These need to be built, not restored
 dotnet build sample/CSharpProject/CSharpProject.csproj
 dotnet build sample/CSharpProject.AssemblyName/CSharpProject.AssemblyName.csproj

--- a/src/FSharpLanguageServer/FSharpLanguageServer.fsproj
+++ b/src/FSharpLanguageServer/FSharpLanguageServer.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/src/LSP/LSP.fsproj
+++ b/src/LSP/LSP.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectCracker/ProjectCracker.fs
+++ b/src/ProjectCracker/ProjectCracker.fs
@@ -82,6 +82,7 @@ type JsonValue with
         result
 
 let private frameworkPreference = [
+    "netcoreapp3.1", ".NETCoreApp,Version=v3.1";
     "netcoreapp3.0", ".NETCoreApp,Version=v3.0";
     "netcoreapp2.2", ".NETCoreApp,Version=v2.2";
     "netcoreapp2.1", ".NETCoreApp,Version=v2.1";

--- a/src/ProjectCracker/ProjectCracker.fs
+++ b/src/ProjectCracker/ProjectCracker.fs
@@ -144,7 +144,7 @@ let private parseProjectAssets(projectAssetsJson: FileInfo): ProjectAssets =
     //
     // The path returned here will have framework DLLs which we need, but which may
     // not be explicitly referenced elsewhere
-    let findRuntimePath(runtime: string, minVersion: string option, maxVersion: string option): string =
+    let findRuntimePath(runtime: string, minVersion: string option, maxVersion: string option): string option =
         let dotnetProcess = new Process()
         dotnetProcess.StartInfo <- new ProcessStartInfo(FileName="dotnet",
                                                         Arguments="--info",
@@ -165,7 +165,7 @@ let private parseProjectAssets(projectAssetsJson: FileInfo): ProjectAssets =
                     found <- Some(Path.Combine(base_path, version))
                 else
                     dprintfn "Framework %s %s out of range (%A, %A)" runtime version minVersion maxVersion
-        found.Value
+        found
     // Choose one of the frameworks listed in project.frameworks
     // by scanning all possible frameworks in order of preference
     let shortFramework, longFramework = 
@@ -290,7 +290,9 @@ let private parseProjectAssets(projectAssetsJson: FileInfo): ProjectAssets =
                     None
                 else
                     Some(maxVersionStr.Trim())
-            runtimeDir <- Some(findRuntimePath(runtimeName, minVersion, maxVersion))
+            match findRuntimePath(runtimeName, minVersion, maxVersion) with
+            | Some dir -> runtimeDir <- Some(dir)
+            | None -> ()
     | None -> ()
     // The runtime directory contains all of the framework DLLs that are implicitly 
     // required, like System.Core.dll

--- a/src/ProjectCracker/ProjectCracker.fs
+++ b/src/ProjectCracker/ProjectCracker.fs
@@ -148,7 +148,7 @@ let private parseProjectAssets(projectAssetsJson: FileInfo): ProjectAssets =
                 inRuntimeBlock <- true
             elif line = "" then
                 inRuntimeBlock <- false
-            elif inRuntimeBlock the:
+            elif inRuntimeBlock then
                 let [| name; version; bracket_path |] = line.Trim().Split([| ' ' |], 3)
                 let base_path = bracket_path.Substring(1, bracket_path.Length - 2)
                 dprintfn "Discovered framework: %s v%s at %s" name version base_path

--- a/src/ProjectCracker/ProjectCracker.fs
+++ b/src/ProjectCracker/ProjectCracker.fs
@@ -152,8 +152,7 @@ let private parseProjectAssets(projectAssetsJson: FileInfo): ProjectAssets =
                 let [| name; version; bracket_path |] = line.Trim().Split([| ' ' |], 3)
                 let base_path = bracket_path.Substring(1, bracket_path.Length - 2)
                 dprintfn "Discovered framework: %s v%s at %s" name version base_path
-                runtimePaths.Add({name=name; version=version; path=Path.Combine(base_path, version)})
-                ()
+                runtimePaths.Add({name=name; version=version; path=Path.Combine(base_path, version)}) |> ignore
         runtimePaths
     // Choose one of the frameworks listed in project.frameworks
     // by scanning all possible frameworks in order of preference
@@ -238,14 +237,11 @@ let private parseProjectAssets(projectAssetsJson: FileInfo): ProjectAssets =
     //                     "autoReferenced": true
     //                 }
     //             },
-    //
-    //             // Only present for projects built in dotnet Core 3.
-    //             "downloadDependencies": [
-    //                 {
-    //                     "name": "Microsoft.NETCore.App.Ref",
-    //                     "version": "[3.0.0, 3.0.0]"
-    //                 }
-    //             ]
+    //             "frameworkReferences": {
+    //                 "Microsoft.NETCore.App": {
+    //                     "privateAssets": "all"
+    //                  }
+    //             }
     //         }
     //     }
     // }
@@ -256,7 +252,6 @@ let private parseProjectAssets(projectAssetsJson: FileInfo): ProjectAssets =
         let version = chooseVersion(name)
         let dep = {name=name; version=version}
         findTransitiveDeps(dep)
-    let mutable runtimeDir: string option = None
     let [| _; longFrameworkVersion |] = longFramework.Split("Version=v")
     let runtimeDirs = HashSet<string>()
     let runtimes = findRuntimePaths()

--- a/src/ProjectCracker/ProjectCracker.fs
+++ b/src/ProjectCracker/ProjectCracker.fs
@@ -148,8 +148,8 @@ let private parseProjectAssets(projectAssetsJson: FileInfo): ProjectAssets =
                 inRuntimeBlock <- true
             elif line = "" then
                 inRuntimeBlock <- false
-            elif inRuntimeBlock then
-                let [| name; version; bracket_path |] = line.Trim().Split()
+            elif inRuntimeBlock the:
+                let [| name; version; bracket_path |] = line.Trim().Split([| ' ' |], 3)
                 let base_path = bracket_path.Substring(1, bracket_path.Length - 2)
                 dprintfn "Discovered framework: %s v%s at %s" name version base_path
                 runtimePaths.Add({name=name; version=version; path=Path.Combine(base_path, version)})

--- a/src/ProjectCracker/ProjectCracker.fs
+++ b/src/ProjectCracker/ProjectCracker.fs
@@ -260,11 +260,15 @@ let private parseProjectAssets(projectAssetsJson: FileInfo): ProjectAssets =
     let [| _; longFrameworkVersion |] = longFramework.Split("Version=v")
     let runtimeDirs = HashSet<string>()
     let runtimes = findRuntimePaths()
-    for frameworkRef, _ in root?project?frameworks.[shortFramework]?frameworkReferences.Properties do
-        for runtime in runtimes do
-            if frameworkRef = runtime.name && runtime.version.StartsWith(longFrameworkVersion) then
-                dprintfn "Found valid runtime for %s version %s at %s" frameworkRef longFrameworkVersion runtime.path
-                runtimeDirs.Add(runtime.path) |> ignore
+    match root?project?frameworks.[shortFramework].TryGetProperty("frameworkReferences") with
+    | Some frameworkRefs ->
+        for frameworkRef, _ in frameworkRefs.Properties do
+            for runtime in runtimes do
+                if frameworkRef = runtime.name && runtime.version.StartsWith(longFrameworkVersion) then
+                    dprintfn "Found valid runtime for %s version %s at %s" frameworkRef longFrameworkVersion runtime.path
+                    runtimeDirs.Add(runtime.path) |> ignore
+    | None -> 
+        ()
     // The runtime directory contains all of the framework DLLs that are implicitly 
     // required, like System.Core.dll
     let runtimeAssemblies =

--- a/src/ProjectCracker/ProjectCracker.fs
+++ b/src/ProjectCracker/ProjectCracker.fs
@@ -572,7 +572,7 @@ let crack(fsproj: FileInfo): CrackedProject =
                 error=None
             }
     with e -> 
-        dprintfn "Failed to build %s %s: %s" fsproj.Name e.Message e.StackTrace
+        dprintfn "Failed to build %s: %s\n%s" fsproj.Name e.Message e.StackTrace
         {
             fsproj=fsproj
             target=placeholderTarget

--- a/src/ProjectCracker/ProjectCracker.fsproj
+++ b/src/ProjectCracker/ProjectCracker.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/FSharpLanguageServer.Tests/FSharpLanguageServer.Tests.fsproj
+++ b/tests/FSharpLanguageServer.Tests/FSharpLanguageServer.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common.fs" />

--- a/tests/LSP.Tests/LSP.Tests.fsproj
+++ b/tests/LSP.Tests/LSP.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ProjectCracker.Tests/ProjectCracker.Tests.fsproj
+++ b/tests/ProjectCracker.Tests/ProjectCracker.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common.fs" />

--- a/tests/ProjectCracker.Tests/ProjectCrackerTests.fs
+++ b/tests/ProjectCracker.Tests/ProjectCrackerTests.fs
@@ -159,3 +159,9 @@ let ``build unbuilt project``() =
     if cracked.error.IsSome then Assert.Fail(cracked.error.Value)
     CollectionAssert.AreEquivalent(["NotBuilt.fs"], [for f in cracked.sources do yield f.Name])
     CollectionAssert.IsNotEmpty(cracked.packageReferences)
+
+[<Test>]
+let ``find implicit references woth netcoreapp3``() =
+    let fsproj = Path.Combine [|projectRoot.FullName; "sample"; "NetCoreApp3"; "NetCoreApp3.fsproj"|] |> FileInfo
+    let cracked = ProjectCracker.crack(fsproj)
+    CollectionAssert.Contains([for f in cracked.packageReferences do yield f.Name], "System.Core.dll")

--- a/tests/ProjectCracker.Tests/ProjectCrackerTests.fs
+++ b/tests/ProjectCracker.Tests/ProjectCrackerTests.fs
@@ -124,7 +124,7 @@ let msbuild(fsproj: FileInfo): string list =
             references.Add(line.Trim().Substring("-r:".Length))
     // Filter out project-to-project references, these are handled separately by ProjectCracker
     [ for r in references do 
-        if not(r.Contains("bin/Debug/netcoreapp2.0")) then 
+        if not(r.Contains("bin/Debug/netcoreapp")) then 
             yield r ]
     
 let cracker(fsproj: FileInfo): string list = 
@@ -161,7 +161,7 @@ let ``build unbuilt project``() =
     CollectionAssert.IsNotEmpty(cracked.packageReferences)
 
 [<Test>]
-let ``find implicit references woth netcoreapp3``() =
+let ``find implicit references with netcoreapp3``() =
     let fsproj = Path.Combine [|projectRoot.FullName; "sample"; "NetCoreApp3"; "NetCoreApp3.fsproj"|] |> FileInfo
     let cracked = ProjectCracker.crack(fsproj)
     CollectionAssert.Contains([for f in cracked.packageReferences do yield f.Name], "System.Core.dll")

--- a/tests/ProjectInfo/ProjectInfo.csproj
+++ b/tests/ProjectInfo/ProjectInfo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/tests/Scratch/Scratch.fsproj
+++ b/tests/Scratch/Scratch.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
This covers the issues with framework assembly detection in netcoreapp3.0 that came up in #66. The other changes are:

- New NetCore3 test and fixes found by failing tests
- Update VS Code build files to handle new netcoreapp3.0 binary paths