### PR TITLE
Add information about AUR to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ npm install
 dotnet build -c Release
 ```
 
+If using a distribution based on Arch Linux, you can also install it from the [AUR](https://aur.archlinux.org/packages/fsharp-language-server/)
+
 Install [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim) 
 
 Update your vim config to point LanguageClient-neovim to the FSharp Language Server for fsharp filetypes:


### PR DESCRIPTION
I've recently found this project, and since I wanted to install it on my system, I've create a package on the Arch User Repository - https://aur.archlinux.org/packages/fsharp-language-server/

I think it would be useful to add information about it to the readme